### PR TITLE
Version 2.0: .NET Core Global Tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,35 +8,29 @@ It is based on [dotnet-gitversion](https://github.com/ah-/dotnet-gitversion), bu
 
 ## Usage
 
-Reference **dotnet-setversion** in your project's `*.csproj` (as below) and then run `dotnet restore` to fetch the package.
-
-```xml
-<Project Sdk="Microsoft.NET.Sdk">
-...
-  <ItemGroup>
-    <DotNetCliToolReference Include="dotnet-setversion" Version="*" />
-  </ItemGroup>
-...
-<Project>
-```
-
-With your project root folder set as the current working directory, invoke the following:
+Install **dotnet-setversion** as a global tool using the dotnet CLI:
 
 ```
-$ dotnet setversion 0.1.2-beta0001
+$ dotnet tool install -g dotnet-setversion
+```
+
+If the command completed successfully, you're able to invoke **dotnet-setversion** in any directory like this:
+
+```
+$ setversion 0.1.2-beta0001
 ```
 
 You can also update the version information of a specific project file by invoking like this:
 
 ```
-$ dotnet setversion 0.1.2-beta0001 MyProject.csproj
+$ setversion 0.1.2-beta0001 MyProject.csproj
 ```
 
 If you happen to have a rather big repo including several project files and you want to update them all at once, you can use the `--recursive` option.  
 This will update any project file in and below the current working directory.
 
 ```
-$ dotnet setversion -r 0.1.2-beta0001
+$ setversion -r 0.1.2-beta0001
 ```
 
 For each example, replace '0.1.2-beta0001' with any valid version string.
@@ -44,7 +38,16 @@ For each example, replace '0.1.2-beta0001' with any valid version string.
 With [GitVersion](https://github.com/GitTools/GitVersion) installed, you can do the following as well:
 
 ```
-$ dotnet setversion $(gitversion -showvariable NugetVersionV2)
+$ dotnet $(gitversion -showvariable NugetVersionV2)
 ```
 
 This (or something similar) can of course be done during a continuous integration build, which is the main intention behind developing this project.
+
+## Migrating from 1.* to 2.*
+
+**dotnet-setversion** used to be a [per-project tool](https://docs.microsoft.com/en-us/dotnet/core/tools/extensibility#per-project-based-extensibility), but has now been reworked as [.NET Core Global Tool](https://docs.microsoft.com/en-us/dotnet/core/tools/global-tools).  
+As a consequence of this, you have to remove the `<DotNetCliToolReference>` element referencing **dotnet-setversion** or you'll get an error when running `dotnet restore`.
+
+Depending on your build strategy, you have to install **setversion** once on your build agent (see [Usage](#usage)) or integrate the install command into your build script.
+
+Finally you have to change the way to invoke the program from `dotnet setversion` to `setversion`.

--- a/README.md
+++ b/README.md
@@ -33,13 +33,7 @@ This will update any project file in and below the current working directory.
 $ setversion -r 0.1.2-beta0001
 ```
 
-For each example, replace '0.1.2-beta0001' with any valid version string.
-
-With [GitVersion](https://github.com/GitTools/GitVersion) installed, you can do the following as well:
-
-```
-$ dotnet $(gitversion -showvariable NugetVersionV2)
-```
+For each example, replace '0.1.2-beta0001' with any valid version string or, when having [GitVersion](https://github.com/GitTools/GitVersion) installed, with `$(GitVersion -ShowVariable NuGetVersionV2)` to use your current version automatically.
 
 This (or something similar) can of course be done during a continuous integration build, which is the main intention behind developing this project.
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This (or something similar) can of course be done during a continuous integratio
 
 ## Migrating from 1.* to 2.*
 
-**dotnet-setversion** used to be a [per-project tool](https://docs.microsoft.com/en-us/dotnet/core/tools/extensibility#per-project-based-extensibility), but has now been reworked as [.NET Core Global Tool](https://docs.microsoft.com/en-us/dotnet/core/tools/global-tools).  
+**dotnet-setversion** used to be a [per-project tool](https://docs.microsoft.com/en-us/dotnet/core/tools/extensibility#per-project-based-extensibility), but has now been reworked as a [.NET Core Global Tool](https://docs.microsoft.com/en-us/dotnet/core/tools/global-tools).  
 As a consequence of this, you have to remove the `<DotNetCliToolReference>` element referencing **dotnet-setversion** or you'll get an error when running `dotnet restore`.
 
 Depending on your build strategy, you have to install **setversion** once on your build agent (see [Usage](#usage)) or integrate the install command into your build script.

--- a/src/dotnet-setversion/dotnet-setversion.csproj
+++ b/src/dotnet-setversion/dotnet-setversion.csproj
@@ -2,12 +2,17 @@
   <PropertyGroup>
     <Description>A CLI tool to set/update the Version property in csproj files</Description>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp1.0;netcoreapp1.1;netcoreapp2.0</TargetFrameworks>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <IsPackable>true</IsPackable>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>setversion</ToolCommandName>
+    <Author>ThymineC</Author>
     <Copyright>Copyright 2018 ThymineC</Copyright>
     <Authors>ThymineC; Skulblaka</Authors>
     <PackageLicenseUrl>https://opensource.org/licenses/MIT</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/TAGC/dotnet-setversion</PackageProjectUrl>
     <RepositoryUrl>git@github.com:TAGC/dotnet-setversion.git</RepositoryUrl>
+    <Version>2.0.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <DotNetCliToolReference Include="dotnet-setversion" Version="1.0.0" />

--- a/src/dotnet-setversion/dotnet-setversion.csproj
+++ b/src/dotnet-setversion/dotnet-setversion.csproj
@@ -12,7 +12,6 @@
     <PackageLicenseUrl>https://opensource.org/licenses/MIT</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/TAGC/dotnet-setversion</PackageProjectUrl>
     <RepositoryUrl>git@github.com:TAGC/dotnet-setversion.git</RepositoryUrl>
-    <Version>2.0.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <DotNetCliToolReference Include="dotnet-setversion" Version="1.0.0" />


### PR DESCRIPTION
This pull request includes the changes required to build `setversion` as .NET Core Global Tool. By offering `setversion` as a global tool, there is no more need for a csproj file to be in the current directory. This allows to to support more complex scenarios e.g. running it at solution level (#1) or in a directory with multiple .csproj files (#9)