### PR TITLE
Fixed crash when folders contain msbuild-style projects.

### DIFF
--- a/src/dotnet-setversion/Program.cs
+++ b/src/dotnet-setversion/Program.cs
@@ -123,7 +123,13 @@ namespace dotnet_setversion
         /// </remarks>
         public static XElement GetOrCreateElement(this XContainer container, string name)
         {
-            var element = container.Element(name);
+            // Checks the root node as well as children
+            // This prevents bombing out on solutions with 
+            // msbuild style projects in it.
+            var element = ((XElement)container.Nodes().FirstOrDefault(n => n is XElement));
+            if (element?.Name.LocalName == name) return element;
+
+            element = container.Element(name);
             if (element != null) return element;
             element = new XElement(name);
             container.Add(element);


### PR DESCRIPTION
I like this tool.  I discovered the bug when performing a recursive update on a solution with mixed dotnet code and msbuild style solutions.  The fix will create "dotnet code" nodes in the msbuild style project, but it won't hurt anything.  It could also be changed to just "move along" or go into an alternative path where it searches for assemblyinfo.cs files to update.