### PR TITLE
Add support for retrieving the version from a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ It is based on [dotnet-gitversion](https://github.com/ah-/dotnet-gitversion), bu
 [![NuGet](https://img.shields.io/nuget/v/dotnet-setversion.svg)](https://www.nuget.org/packages/dotnet-setversion)
 [![Build status](https://ci.appveyor.com/api/projects/status/5e4apspa6wg86t9n/branch/master?svg=true)](https://ci.appveyor.com/project/TAGC/dotnet-setversion/branch/master)
 
-
 ## Usage
 
 Install **dotnet-setversion** as a global tool using the dotnet CLI:
@@ -26,12 +25,38 @@ You can also update the version information of a specific project file by invoki
 $ setversion 0.1.2-beta0001 MyProject.csproj
 ```
 
+### Recursive updates
+
 If you happen to have a rather big repo including several project files and you want to update them all at once, you can use the `--recursive` option.  
 This will update any project file in and below the current working directory.
 
 ```
 $ setversion -r 0.1.2-beta0001
 ```
+
+### Extracting the version from a file
+
+As well as passing the version directly, you can specify a file to extract the version number from. This is done by prefixing the version argument with an `@` symbol. For example, the following command will make the tool try to extract the version from a file in the working directory called "sem.ver".
+
+```
+$ setversion @sem.ver
+```
+
+The file should represent the version either as a simple string (i.e. in the same format you'd ordinarily provide directly to the tool, such as `0.1.2`) or in JSON format using a schema like this:
+
+```json
+{
+  "Version": {
+    "Major": 0,
+    "Minor": 1,
+    "Patch": 2
+  }
+}
+```
+
+Bear in mind that the JSON format does not support metadata extensions (e.g. `-beta0001`).
+
+### Further notes
 
 For each example, replace '0.1.2-beta0001' with any valid version string or, when having [GitVersion](https://github.com/GitTools/GitVersion) installed, with `$(GitVersion -ShowVariable NuGetVersionV2)` to use your current version automatically.
 

--- a/src/dotnet-setversion/Options.cs
+++ b/src/dotnet-setversion/Options.cs
@@ -11,7 +11,18 @@ namespace dotnet_setversion
             "Mutually exclusive to the csprojFile argument.")]
         public bool Recursive { get; set; }
 
-        [Value(0, MetaName = "version", HelpText = "The version to apply to the given csproj file(s).",
+        /*
+{
+  "Version": {
+    "Major": 2,
+    "Minor": 2,
+    "Patch": 0
+  }
+}         */
+        [Value(0, MetaName = "version", HelpText = "The version to apply to the given csproj file(s). A filename " + 
+                "can also be referenced by prepending an @filename to read the version number from the file." +
+                "The file is expected to contain either a simple version or a JSON value in the following format:" +
+                "{Version: {Major:Value, Minor:Value, Patch:Value}}",
             Required = true)]
         public string Version { get; set; }
 

--- a/src/dotnet-setversion/Options.cs
+++ b/src/dotnet-setversion/Options.cs
@@ -40,6 +40,7 @@ namespace dotnet_setversion
                     new Options {Version = "1.2.3", CsprojFile = "MyProject.csproj"});
                 yield return new Example("Large repo with multiple csproj files in nested directories",
                     new UnParserSettings {PreferShortName = true}, new Options {Version = "1.2.3", Recursive = true});
+                yield return new Example("Pulling the version from a file", new Options {Version = "@sem.ver"});
             }
         }
     }

--- a/src/dotnet-setversion/VersionModel.cs
+++ b/src/dotnet-setversion/VersionModel.cs
@@ -1,12 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace dotnet_setversion
+﻿namespace dotnet_setversion
 {
     public class VersionModel
     {
         public VersionModelDetail Version { get; set; }
+        
         public override string ToString()
         {
             if (Version != null)
@@ -14,7 +11,7 @@ namespace dotnet_setversion
                 return $"{Version.Major}.{Version.Minor}.{Version.Patch}";
             }
 
-            return "";
+            return string.Empty;
         }
     }
 

--- a/src/dotnet-setversion/VersionModel.cs
+++ b/src/dotnet-setversion/VersionModel.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace dotnet_setversion
+{
+    public class VersionModel
+    {
+        public VersionModelDetail Version { get; set; }
+        public override string ToString()
+        {
+            if (Version != null)
+            {
+                return $"{Version.Major}.{Version.Minor}.{Version.Patch}";
+            }
+
+            return "";
+        }
+    }
+
+    public class VersionModelDetail
+    {
+        public int Major { get; set; }
+        public int Minor { get; set; }
+        public int Patch { get; set; }
+    }
+}

--- a/src/dotnet-setversion/dotnet-setversion.csproj
+++ b/src/dotnet-setversion/dotnet-setversion.csproj
@@ -15,5 +15,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.2.1" />
+    <PackageReference Include="System.Text.Json" Version="4.6.0" />
   </ItemGroup>
 </Project>

--- a/test/integration/SetVersion.cs
+++ b/test/integration/SetVersion.cs
@@ -119,5 +119,39 @@ namespace integration
 
             Assert.NotEqual(0, exitCode);
         }
+
+        [Fact]
+        public void ApplyingVersion_WithoutSpecifyingCsprojFileWithSimpleVersionFromFile()
+        {
+            const string version = "1.2.3";
+            const string versionFilename = "@sem.ver";
+            var workingDirectory = _testHelper.ChangeToRandomDirectory();
+            using (var semFileWriter = File.CreateText(Path.Combine(workingDirectory, "sem.ver")))
+            {
+                semFileWriter.Write(version);
+            }
+            var csprojFile = Path.Combine(workingDirectory, "Project.csproj");
+            _testHelper.CopyExampleFile(csprojFile);
+
+            var exitCode = Program.Main(versionFilename);
+
+            Assert.Equal(0, exitCode);
+            _testHelper.CheckCsprojFile(version, csprojFile);
+        }
+
+        [Fact]
+        public void ApplyingVersion_WithoutSpecifyingCsprojFileWithVersionFromJsonFile()
+        {
+            const string version = "1.2.3";
+            const string versionFilename = "@sem.ver";
+            var workingDirectory = _testHelper.ChangeToRandomDirectory();
+            var csprojFile = Path.Combine(workingDirectory, "Project.csproj");
+            _testHelper.CopyExampleFile(csprojFile);
+            _testHelper.CopyExampleSemVerFile("sem.ver");
+            var exitCode = Program.Main(versionFilename);
+
+            Assert.Equal(0, exitCode);
+            _testHelper.CheckCsprojFile(version, csprojFile);
+        }
     }
 }

--- a/test/integration/SetVersion.cs
+++ b/test/integration/SetVersion.cs
@@ -153,5 +153,17 @@ namespace integration
             Assert.Equal(0, exitCode);
             _testHelper.CheckCsprojFile(version, csprojFile);
         }
+
+        [Fact]
+        public void SetVersion_ReturnsNonZero_WhenExtractingVersionFromNonExistentFile()
+        {
+            var workingDirectory = _testHelper.ChangeToRandomDirectory();
+            var csprojFile = Path.Combine(workingDirectory, "Project.csproj");
+            _testHelper.CopyExampleFile(csprojFile);
+
+            var exitCode = Program.Main("@non_existent_file");
+
+            Assert.NotEqual(0, exitCode);
+        }
     }
 }

--- a/test/integration/TestHelper.cs
+++ b/test/integration/TestHelper.cs
@@ -12,9 +12,22 @@ namespace integration
   </PropertyGroup>
 </Project>";
 
+        public string ExampleSemVerFile { get; } = @"{
+""Version"": {
+    ""Major"": 1,
+    ""Minor"": 2,
+    ""Patch"": 3
+    }
+}";
+
         public void CopyExampleFile(string path, bool overwrite = false)
         {
             File.WriteAllText(path, ExampleCsprojFile);
+        }
+
+        public void CopyExampleSemVerFile(string path, bool overwrite = false)
+        {
+            File.WriteAllText(path, ExampleSemVerFile);
         }
 
         public void CheckCsprojFile(string version, params string[] files)

--- a/test/integration/integration.csproj
+++ b/test/integration/integration.csproj
@@ -25,6 +25,4 @@
     <Folder Include="Properties\" />
   </ItemGroup>
 
-  <ProjectExtensions><VisualStudio><UserProperties version_1json__JsonSchema="" /></VisualStudio></ProjectExtensions>
-
 </Project>

--- a/test/integration/integration.csproj
+++ b/test/integration/integration.csproj
@@ -25,4 +25,6 @@
     <Folder Include="Properties\" />
   </ItemGroup>
 
+  <ProjectExtensions><VisualStudio><UserProperties version_1json__JsonSchema="" /></VisualStudio></ProjectExtensions>
+
 </Project>


### PR DESCRIPTION
In our environment, we have the semantic version in a sem.ver file. I have added support to setversion to read the version from a file if the version parameter is prefaced with an @ followed by a filename. It supports both reading a simple version number (1.2.3) from the file or a more complex JSON model containing Major, Minor, Patch.