### PR TITLE
Add support for updating version prefix in csproj file

### DIFF
--- a/src/dotnet-setversion/Options.cs
+++ b/src/dotnet-setversion/Options.cs
@@ -29,7 +29,11 @@ namespace dotnet_setversion
         [Value(1, MetaName = "csprojFile", Required = false, HelpText =
             "Path to a csproj file to apply the given version. Mutually exclusive to the --recursive option.")]
         public string CsprojFile { get; set; }
-
+        
+        [Option('p', "prefix", Default = false, HelpText = 
+            "Set version using the VersionPrefix element for csproj files.")]
+        public bool VersionPrefix { get; set; }
+        
         [Usage(ApplicationAlias = "setversion")]
         public static IEnumerable<Example> Examples
         {

--- a/test/integration/SetVersion.cs
+++ b/test/integration/SetVersion.cs
@@ -19,7 +19,7 @@ namespace integration
             var exitCode = Program.Main(version);
 
             Assert.Equal(0, exitCode);
-            _testHelper.CheckCsprojFile(version, csprojFile);
+            _testHelper.CheckCsprojFileForVersionElement(version, csprojFile);
         }
 
         [Fact]
@@ -54,7 +54,7 @@ namespace integration
             var exitCode = Program.Main(version, csprojFile);
 
             Assert.Equal(0, exitCode);
-            _testHelper.CheckCsprojFile(version, csprojFile);
+            _testHelper.CheckCsprojFileForVersionElement(version, csprojFile);
         }
         
         [Fact]
@@ -67,7 +67,7 @@ namespace integration
             var exitCode = Program.Main(version, csprojFile, "-p");
 
             Assert.Equal(0, exitCode);
-            _testHelper.CheckCsprojFile(version, csprojFile);
+            _testHelper.CheckCsprojFileForVersionPrefixElement(version, csprojFile);
         }
 
         [Fact]
@@ -83,7 +83,7 @@ namespace integration
             var exitCode = Program.Main(version, csprojFileA);
 
             Assert.Equal(0, exitCode);
-            _testHelper.CheckCsprojFile(version, csprojFileA);
+            _testHelper.CheckCsprojFileForVersionElement(version, csprojFileA);
             // check the other file remains untouched.
             Assert.Equal(_testHelper.ExampleCsprojFile, File.ReadAllText(csprojFileB));
         }
@@ -119,10 +119,10 @@ namespace integration
             var exitCode = Program.Main("-r", version);
 
             Assert.Equal(0, exitCode);
-            _testHelper.CheckCsprojFile(version, projectA);
-            _testHelper.CheckCsprojFile(version, projectB);
-            _testHelper.CheckCsprojFile(version, moduleFileA);
-            _testHelper.CheckCsprojFile(version, moduleFileB);
+            _testHelper.CheckCsprojFileForVersionElement(version, projectA);
+            _testHelper.CheckCsprojFileForVersionElement(version, projectB);
+            _testHelper.CheckCsprojFileForVersionElement(version, moduleFileA);
+            _testHelper.CheckCsprojFileForVersionElement(version, moduleFileB);
         }
         
         [Fact]
@@ -146,10 +146,10 @@ namespace integration
             var exitCode = Program.Main("-r", "-p", version);
 
             Assert.Equal(0, exitCode);
-            _testHelper.CheckCsprojFile(version, projectA);
-            _testHelper.CheckCsprojFile(version, projectB);
-            _testHelper.CheckCsprojFile(version, moduleFileA);
-            _testHelper.CheckCsprojFile(version, moduleFileB);
+            _testHelper.CheckCsprojFileForVersionPrefixElement(version, projectA);
+            _testHelper.CheckCsprojFileForVersionPrefixElement(version, projectB);
+            _testHelper.CheckCsprojFileForVersionPrefixElement(version, moduleFileA);
+            _testHelper.CheckCsprojFileForVersionPrefixElement(version, moduleFileB);
         }
 
         [Fact]
@@ -176,7 +176,7 @@ namespace integration
             var exitCode = Program.Main(versionFilename);
 
             Assert.Equal(0, exitCode);
-            _testHelper.CheckCsprojFile(version, csprojFile);
+            _testHelper.CheckCsprojFileForVersionElement(version, csprojFile);
         }
 
         [Fact]
@@ -195,7 +195,7 @@ namespace integration
             var exitCode = Program.Main(versionFilename);
 
             Assert.Equal(0, exitCode);
-            _testHelper.CheckCsprojFile("1.2.3", csprojFile);
+            _testHelper.CheckCsprojFileForVersionElement("1.2.3", csprojFile);
         }
 
         [Fact]
@@ -210,7 +210,7 @@ namespace integration
             var exitCode = Program.Main(versionFilename);
 
             Assert.Equal(0, exitCode);
-            _testHelper.CheckCsprojFile(version, csprojFile);
+            _testHelper.CheckCsprojFileForVersionElement(version, csprojFile);
         }
 
         [Fact]

--- a/test/integration/SetVersion.cs
+++ b/test/integration/SetVersion.cs
@@ -56,6 +56,19 @@ namespace integration
             Assert.Equal(0, exitCode);
             _testHelper.CheckCsprojFile(version, csprojFile);
         }
+        
+        [Fact]
+        public void ApplyingVersion_WithVersionPrefix()
+        {
+            var csprojFile = Path.GetTempFileName();
+            _testHelper.CopyExampleFile(csprojFile, true);
+            const string version = "1.2.3-123";
+
+            var exitCode = Program.Main(version, csprojFile, "-p");
+
+            Assert.Equal(0, exitCode);
+            _testHelper.CheckCsprojFile(version, csprojFile);
+        }
 
         [Fact]
         public void ApplyingVersions_WithMultipleProjectFilesInCurrentDirectory_WhenSpecifyingProjectFile()
@@ -104,6 +117,33 @@ namespace integration
             _testHelper.CopyExampleFile(moduleFileB);
 
             var exitCode = Program.Main("-r", version);
+
+            Assert.Equal(0, exitCode);
+            _testHelper.CheckCsprojFile(version, projectA);
+            _testHelper.CheckCsprojFile(version, projectB);
+            _testHelper.CheckCsprojFile(version, moduleFileA);
+            _testHelper.CheckCsprojFile(version, moduleFileB);
+        }
+        
+        [Fact]
+        public void ApplyingVersionPrefixToAllFiles_WhenRecursive()
+        {
+            const string projectA = "Project A.csproj";
+            const string projectB = "Project B.csproj";
+            const string moduleA = "Module A";
+            const string moduleB = "Module B";
+            const string version = "1.2.3-123";
+            var moduleFileA = Path.Combine(moduleA, moduleA + ".csproj");
+            var moduleFileB = Path.Combine(moduleB, moduleB + ".csproj");
+            _testHelper.ChangeToRandomDirectory();
+            _testHelper.CopyExampleFile(projectA);
+            _testHelper.CopyExampleFile(projectB);
+            Directory.CreateDirectory(moduleA);
+            Directory.CreateDirectory(moduleB);
+            _testHelper.CopyExampleFile(moduleFileA);
+            _testHelper.CopyExampleFile(moduleFileB);
+
+            var exitCode = Program.Main("-r", "-p", version);
 
             Assert.Equal(0, exitCode);
             _testHelper.CheckCsprojFile(version, projectA);

--- a/test/integration/TestHelper.cs
+++ b/test/integration/TestHelper.cs
@@ -35,7 +35,12 @@ namespace integration
             foreach (var file in files)
             {
                 var content = File.ReadAllText(file);
-                Assert.Contains($"<Version>{version}</Version>", content);
+
+                var expectedVersionElement = content.Contains("Prefix")
+                    ? $"<VersionPrefix>{version}</VersionPrefix>"
+                    : $"<Version>{version}</Version>";
+                
+                Assert.Contains(expectedVersionElement, content);
             }
         }
 

--- a/test/integration/TestHelper.cs
+++ b/test/integration/TestHelper.cs
@@ -30,17 +30,21 @@ namespace integration
             File.WriteAllText(path, ExampleSemVerFile);
         }
 
-        public void CheckCsprojFile(string version, params string[] files)
+        public void CheckCsprojFileForVersionElement(string version, params string[] files)
         {
             foreach (var file in files)
             {
                 var content = File.ReadAllText(file);
+                Assert.Contains($"<Version>{version}</Version>", content);
+            }
+        }
 
-                var expectedVersionElement = content.Contains("Prefix")
-                    ? $"<VersionPrefix>{version}</VersionPrefix>"
-                    : $"<Version>{version}</Version>";
-                
-                Assert.Contains(expectedVersionElement, content);
+        public void CheckCsprojFileForVersionPrefixElement(string version, params string[] files)
+        {
+            foreach (var file in files)
+            {
+                var content = File.ReadAllText(file);
+                Assert.Contains($"<VersionPrefix>{version}</VersionPrefix>", content);
             }
         }
 


### PR DESCRIPTION
In order to use the version suffix command with dotnet pack the `<Version />` element needs to be a `<VersionPrefix />` element.

Adding option to update version prefix instead of version.