### PR TITLE
Support .NET 8

### DIFF
--- a/src/dotnet-setversion/dotnet-setversion.csproj
+++ b/src/dotnet-setversion/dotnet-setversion.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>A CLI tool to set/update the Version property in csproj files</Description>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>setversion</ToolCommandName>

--- a/test/integration/TestHelper.cs
+++ b/test/integration/TestHelper.cs
@@ -8,7 +8,7 @@ namespace integration
         public string ExampleCsprojFile { get; } = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <Description>An example csproj file.</Description>
-    <TargetFrameworks>net7.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
   </PropertyGroup>
 </Project>";
 

--- a/test/integration/integration.csproj
+++ b/test/integration/integration.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
 	<IsPackable>false</IsPackable>
     <AssemblyName>integration</AssemblyName>
     <RootNamespace>integration</RootNamespace>
@@ -14,9 +14,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
This upgrades the projects to support .NET 8, mirroring the changes for .NET 7.

Note that .NET Core 2.1, .NET Core 3.1, and .NET 5 are no longer supported by Microsoft, and may contain vulnerabilities. This PR maintains the status quo of supporting those, but they probably should be removed soon in a separate change.

Resolves #28 