### PR TITLE
Drop .NET (Core) 2.1-5 support, #30

### DIFF
--- a/src/dotnet-setversion/dotnet-setversion.csproj
+++ b/src/dotnet-setversion/dotnet-setversion.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>A CLI tool to set/update the Version property in csproj files</Description>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>setversion</ToolCommandName>
@@ -15,6 +15,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="System.Text.Json" Version="[5.0.2,6)" />
+    <PackageReference Include="System.Text.Json" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/test/integration/integration.csproj
+++ b/test/integration/integration.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
 	<IsPackable>false</IsPackable>
     <AssemblyName>integration</AssemblyName>
     <RootNamespace>integration</RootNamespace>


### PR DESCRIPTION
This removes support for .NET Core 2.1, .NET Core 3.1, and .NET 5 which are now out of support from Microsoft.

Additionally, now that .NET Core 2.1 is no longer supported, the old System.Text.Json version is no longer needed. This updates System.Text.Json to 8.0.0 which supports .NET 6+ in use here.

Resolves #30