### PR TITLE
Replace "cinst" with "choco install" in Appveyor config

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ branches:
   - develop
   - /release\/.+/
 install:
-  - cinst gitversion.portable -y
+  - choco install gitversion.portable -y
   - ps: dotnet tool install --global dotnet-setversion
 before_build:
   - nuget restore


### PR DESCRIPTION
Replaces "cinst" (which has been deprecated and removed) with "choco install" in the Appveyor config 