### PR TITLE
Add support for .NET 10, and update all dependencies

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,7 @@ deploy:
   provider: NuGet
   skip_symbols: false
   api_key:
-    secure: KAu0YxpiSIMsKj+Rpy3rc1AGN/WYljKE2Mt8f72UbMzvaLPGllHUFw8UDZ9rwsUY
+    secure: 5v2Aur7bboVNRpX2K/cIOruZgXySbwiBXGGCS+VBBM0TSv3bFQfIjgfPCyDlyw3A
   artifact: NuGet packages
   on:
     branch: master

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,13 +1,21 @@
 image: Visual Studio 2022
+environment:
+  DOTNET_NOLOGO: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: 1
 branches:
   only:
   - master
   - develop
   - /release\/.+/
 install:
+  # Workaround from GitHub issue #3984 to install .NET 10 SDK
+  - ps: |
+      Invoke-WebRequest -Uri 'https://dot.net/v1/dotnet-install.ps1' -UseBasicParsing -OutFile "$env:temp\dotnet-install.ps1"
+      & $env:temp\dotnet-install.ps1 -Architecture x64 -Version '10.0.100' -InstallDir "$env:ProgramFiles\dotnet"
   - choco install gitversion.portable -y
   - ps: dotnet tool install --global dotnet-setversion
 before_build:
+  - dotnet --version # Verify .NET 10 is active
   - nuget restore
   - ps: |
       if ($env:APPVEYOR_REPO_BRANCH -eq 'master') {

--- a/dotnet-setversion.sln
+++ b/dotnet-setversion.sln
@@ -6,7 +6,6 @@ MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{FE23C2A7-75C4-4071-B555-0AEB678A9770}"
 	ProjectSection(SolutionItems) = preProject
 		appveyor.yml = appveyor.yml
-		docker-compose.yml = docker-compose.yml
 		GitVersion.yml = GitVersion.yml
 	EndProjectSection
 EndProject

--- a/dotnet-setversion.sln
+++ b/dotnet-setversion.sln
@@ -6,6 +6,7 @@ MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{FE23C2A7-75C4-4071-B555-0AEB678A9770}"
 	ProjectSection(SolutionItems) = preProject
 		appveyor.yml = appveyor.yml
+		docker-compose.yml = docker-compose.yml
 		GitVersion.yml = GitVersion.yml
 	EndProjectSection
 EndProject

--- a/src/dotnet-setversion/dotnet-setversion.csproj
+++ b/src/dotnet-setversion/dotnet-setversion.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>A CLI tool to set/update the Version property in csproj files</Description>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>setversion</ToolCommandName>
@@ -16,7 +16,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="System.Text.Json" Version="9.0.0" />
+    <PackageReference Include="System.Text.Json" Version="10.0.0" />
   </ItemGroup>
   <ItemGroup>
     <None Include="README.md" Pack="true" PackagePath="\" />

--- a/test/integration/TestHelper.cs
+++ b/test/integration/TestHelper.cs
@@ -8,7 +8,7 @@ namespace integration
         public string ExampleCsprojFile { get; } = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <Description>An example csproj file.</Description>
-    <TargetFrameworks>net9.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
   </PropertyGroup>
 </Project>";
 

--- a/test/integration/integration.csproj
+++ b/test/integration/integration.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
 	<IsPackable>false</IsPackable>
     <AssemblyName>integration</AssemblyName>
     <RootNamespace>integration</RootNamespace>
@@ -14,9 +14,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
This PR adds support for .NET 10 and I also updated all packages to their latest version.

Unfortunately, the new 10.x version packages dropped support for .NET 6 and .NET 7, therefore I removed these two frameworks. I think this is okay as they are out of support, and it's better not to depend on older packages - but please let me know what you think.